### PR TITLE
base64: escape invalid UTF-8 characters before encoding

### DIFF
--- a/base64-helpers.js
+++ b/base64-helpers.js
@@ -1,10 +1,31 @@
 (function(exports) {
+    // Returns true if the passed string consists of codepoints between 0 and 255
+    // which are valid within UTF-8.
+    function all_bytes_valid_utf8 (str) {
+        var invalid_chars = [0xc0, 0xc1, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9,
+                             0xF0, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF];
+
+        for (var i in str) {
+            var cp = str.codePointAt(i);
+            if (cp > 255 || invalid_chars.indexOf(cp) !== -1) {
+                return false
+            }
+        }
+
+        return true;
+    };
+
+    // Decodes the string before base64-encoding.
+    function encode_escaped (str) {
+        return window.btoa(unescape(encodeURIComponent(str)));
+    };
+
     // If passed string is UTF-8, decodes to bytes first before encoding.
     exports.encode = function (str) {
-        try {
+        if (all_bytes_valid_utf8(str)) {
             return window.btoa(str);
-        } catch (InvalidCharacterError) {
-            return window.btoa(unescape(encodeURIComponent(str)));
+        } else {
+            return encode_escaped(str);
         }
     };
 


### PR DESCRIPTION
Fixes #9234.

Adapted from https://github.com/artefactual/archivematica/pull/367.
